### PR TITLE
Fix API endpoints and proxy configuration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,26 @@ app.get('/api/structure', async (req, res) => {
   }
 })
 
+// 📄 GET /api/contents?owner=facebook&repo=react&topic=Component
+app.get('/api/contents', async (req, res) => {
+  try {
+    const { owner, repo, topic } = req.query
+    if (!owner || !repo || !topic) return res.status(400).json({ error: 'owner, repo, topic are required' })
+
+    const client = await getMcpClient()
+    const result = await client.tool.invoke({
+      server: { type: 'sse', url: 'https://mcp.deepwiki.com/sse' },
+      toolName: 'read_wiki_contents',
+      arguments: { owner, repo, topic },
+    })
+
+    res.json({ ok: true, data: result?.content ?? [] })
+  } catch (err) {
+    console.error('contents error', err)
+    res.status(500).json({ ok: false, error: err?.message || 'unknown error' })
+  }
+})
+
 // ❓ POST /api/ask  body: { owner, repo, question }
 app.post('/api/ask', async (req, res) => {
     try {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,8 @@
 // ==============================
 import { useEffect, useMemo, useState } from 'react'
 
-const API_BASE = 'http://localhost:5174' // 🔁 points to our Node proxy
+// Use same-origin calls; Vite will proxy /api requests to the local server
+const API_BASE = '/api'
 
 export default function App() {
   // 🧱 Local component state – simple and explicit
@@ -48,7 +49,7 @@ export default function App() {
       setLoading(true)
       setError('')
       try {
-        const url = new URL('/api/structure', API_BASE)
+        const url = new URL(`${API_BASE}/structure`, window.location.origin)
         url.searchParams.set('owner', owner)
         url.searchParams.set('repo', repo)
         const res = await fetch(url.href)
@@ -74,7 +75,7 @@ export default function App() {
     setLoading(true)
     setError('')
     try {
-      const url = new URL('/api/contents', API_BASE)
+      const url = new URL(`${API_BASE}/contents`, window.location.origin)
       url.searchParams.set('owner', owner)
       url.searchParams.set('repo', repo)
       url.searchParams.set('topic', topic)
@@ -100,7 +101,7 @@ export default function App() {
     setLoading(true)
     setError('')
     try {
-      const res = await fetch(`${API_BASE}/api/ask`, {
+      const res = await fetch(`${API_BASE}/ask`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ owner, repo, question })

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5174'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- use same-origin `/api` calls from the React app
- proxy `/api` requests through Vite to the local server
- add missing `/api/contents` endpoint on the Express proxy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68bbf83f2ecc83218b3a1e080aec9a70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /api/contents endpoint to retrieve content by topic.
- Bug Fixes
  - Corrected ask endpoint path to /api/ask, fixing request failures.
- Chores
  - Moved client requests to same-origin using a unified /api base for more consistent networking.
  - Introduced a development proxy that routes /api requests to the backend, simplifying local setup and reducing CORS issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->